### PR TITLE
fixed the arg issue wrong number error with command block

### DIFF
--- a/charts/argo-cd/templates/redis/deployment.yaml
+++ b/charts/argo-cd/templates/redis/deployment.yaml
@@ -63,15 +63,16 @@ spec:
       - name: {{ .Values.redis.name }}
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: {{ default .Values.global.image.imagePullPolicy .Values.redis.image.imagePullPolicy }}
-        args:
-        {{- with .Values.redis.extraArgs }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
-        - --save
-        - ""
-        - --appendonly
-        - "no"
-        - --requirepass $(cat /mnt/secrets/redis-password/_k8s_argocd_redis_password)
+        #needs to rearraged once the test is successful
+        command:
+          - /bin/sh
+          - -c
+          - |
+            REDIS_PASSWORD_1=$(cat /mnt/secrets/redis-password/_k8s_argocd_redis_password) && \
+            exec redis-server \
+              --save "" \
+              --appendonly no \
+              --requirepass "$REDIS_PASSWORD_1" 
         env:
         {{- with (concat .Values.global.env .Values.redis.env) }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
