### PR TITLE
testing argocd to use redis csi secret

### DIFF
--- a/charts/argo-cd/templates/redis/health-configmap.yaml
+++ b/charts/argo-cd/templates/redis/health-configmap.yaml
@@ -42,7 +42,7 @@ data:
     if [ -n "$REDIS_PASSWORD" ]; then
       PASSWORD="$REDIS_PASSWORD"
     elif [ -f /mnt/secrets/redis-password/_k8s_argocd_redis_password ]; then
-      PASSWORD=$(cat /mnt/secrets/redis-password/_k8s_argocd_redis_password | tr -d '\r\n')
+      PASSWORD=$(cat /mnt/secrets/redis-password/_k8s_argocd_redis_password)
     else
       echo "[ERROR] Redis password not found!"
       exit 1

--- a/charts/argo-cd/values.yaml
+++ b/charts/argo-cd/values.yaml
@@ -1989,7 +1989,11 @@ server:
   args:
     - -c
     - |
-        REDIS_PASSWORD=""
+        REDIS_PASSWORD=$(cat /mnt/secrets/redis-password/_k8s_argocd_redis_password)
+        if [ -z "$REDIS_PASSWORD" ]; then
+          echo "Error: REDIS_PASSWORD is not set. Please provide a valid Redis password."
+          exit 1
+        fi
         exec /usr/local/bin/argocd-server --port=8080 --metrics-port=8083;
 
   # -- Additional command line arguments to pass to Argo CD server


### PR DESCRIPTION
<!--
Note on DCO:

If the DCO action in the integration test fails, one or more of your commits are not signed off. Please click on the *Details* link next to the DCO action for instructions on how to resolve this.
-->

Checklist:

* [ ] I have bumped the chart version according to [versioning](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#versioning)
* [ ] I have updated the documentation according to [documentation](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#documentation)
* [ ] I have updated the chart changelog with all the changes that come with this pull request according to [changelog](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#changelog).
* [ ] Any new values are backwards compatible and/or have sensible default.
* [ ] I have signed off all my commits as required by [DCO](https://github.com/argoproj/argoproj/blob/master/community/CONTRIBUTING.md).
* [ ] I have created a separate pull request for each chart according to [pull requests](https://github.com/argoproj/argo-helm/blob/main/CONTRIBUTING.md#pull-requests)
* [ ] My build is green ([troubleshooting builds](https://argo-cd.readthedocs.io/en/stable/developer-guide/ci/)).

<!-- Changes are automatically published when merged to `main`. They are not published on branches. -->
